### PR TITLE
git-module-installer 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# git-module-installer [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/git-module-installer.svg)](https://www.npmjs.com/package/git-module-installer) [![Downloads](https://img.shields.io/npm/dt/git-module-installer.svg)](https://www.npmjs.com/package/git-module-installer) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# git-module-installer
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/git-module-installer.svg)](https://www.npmjs.com/package/git-module-installer) [![Downloads](https://img.shields.io/npm/dt/git-module-installer.svg)](https://www.npmjs.com/package/git-module-installer) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Clone git repositories and install their npm dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-module-installer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Clone git repositories and install their npm dependencies.",
   "main": "lib/index.js",
   "directories": {
@@ -31,6 +31,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
